### PR TITLE
Pin sonarr/radarr/jackett to current LinuxServer stable

### DIFF
--- a/apps/jackett/values.yaml
+++ b/apps/jackett/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: linuxserver/jackett
-  tag: latest
+  tag: v0.24.2027-ls423
   pullPolicy: IfNotPresent
 
 service:

--- a/apps/radarr/values.yaml
+++ b/apps/radarr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: linuxserver/radarr
-  tag: latest
+  tag: 6.2.1.10461-ls306
   pullPolicy: IfNotPresent
 
 service:

--- a/apps/sonarr/values.yaml
+++ b/apps/sonarr/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: linuxserver/sonarr
-  tag: latest
+  tag: 4.0.17.2952-ls314
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
## What

Pins the *arr/jackett image tags from the floating `latest` to current LinuxServer stable releases. These pods had been frozen on April 2025 builds (`pullPolicy: IfNotPresent` + a stale cached `latest` meant they never re-pulled), so merging this both pins **and** rolls them forward.

| App | Running now | New pin |
|-----|-------------|---------|
| Sonarr | `4.0.14.2939-ls277` (Apr 2025) | `4.0.17.2952-ls314` |
| Radarr | `5.21.1.9799-ls267` (Mar 2025) | `6.2.1.10461-ls306` |
| Jackett | `v0.22.1756-ls732` (Apr 2025) | `v0.24.2027-ls423` |

## Verified on the host

- All three pinned images pull for the host arch (digests cached/valid).
- Host is Ubuntu 24.04 / GLIBC 2.39 — clears Radarr v6's SQLite/GLIBC requirement.

## ⚠️ Breaking change — Radarr v5 → v6

Major version bump. Radarr v6's SQLite schema migration is **one-directional**: once v6 opens `radarr.db`, v5 can no longer use it. Rollback requires restoring a pre-upgrade DB backup.

Restore point exists: automatic backup `radarr_backup_v5.21.1.9799_2026.06.21.zip` on the retained config PVC. Sonarr and Jackett bumps are low-risk.

Merging triggers ArgoCD to sync and roll the pods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)