### PR TITLE
Remove invalid mountPath from downloads hostPath volume (sonarr/radarr)

### DIFF
--- a/apps/radarr/templates/deployment.yaml
+++ b/apps/radarr/templates/deployment.yaml
@@ -55,7 +55,6 @@ spec:
         - name: downloads
           hostPath:
             path: {{ .Values.volumes.downloads.hostPath }}
-            mountPath: {{ .Values.volumes.downloads.mountPath }}
         - name: nas-check
           hostPath:
             path: /mnt/nas

--- a/apps/sonarr/templates/deployment.yaml
+++ b/apps/sonarr/templates/deployment.yaml
@@ -55,7 +55,6 @@ spec:
         - name: downloads
           hostPath:
             path: {{ .Values.volumes.downloads.hostPath }}
-            mountPath: {{ .Values.volumes.downloads.mountPath }}
         - name: nas-check
           hostPath:
             path: /mnt/nas


### PR DESCRIPTION
## What

`mountPath` is not a valid field on a `hostPath` volume **source** — it belongs under the container's `volumeMounts` (where it's already correctly set). The API server silently strips the stray field on admission, so the live Deployment never matched the rendered manifest and ArgoCD reported **sonarr** and **radarr** as permanently `OutOfSync`.

```yaml
        - name: downloads
          hostPath:
            path: {{ .Values.volumes.downloads.hostPath }}
            mountPath: {{ .Values.volumes.downloads.mountPath }}   # <-- removed
```

Jackett has no such volume, which is why it was already `Synced`.

## Impact

No-op at runtime — the mount works today via `volumeMounts`. This only removes the persistent ArgoCD drift so both apps reconcile to `Synced`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)